### PR TITLE
Update airt_record.py

### DIFF
--- a/python/airt_record.py
+++ b/python/airt_record.py
@@ -54,7 +54,7 @@ while file_ctr < nfiles:
 
     # Make sure that the proper number of samples was read
     rc = sr.ret
-    assert rc == N, 'Error {}: {}'.format(rc, errToStr(rc))
+    assert rc == N, 'Error {}: {}'.format(rc, errToStr(rc))     # I am getting OverFlow Error due to this line and can't able to rectify it. Can anyone send the modified Code.
 
     # Write buffer to multiple files. Reshaping the rx_buffer allows for iteration
     for file_data in rx_buff.reshape(files_per_buffer, real_samples_per_file):


### PR DESCRIPTION
Hiii

When I am trying to execute the airt_recod.py python for recording the mentioned number of files, I am getting OVERFLOW Error like Error -4 : OVERFLOW. How to rectify this error and please send me the error free code of airt_record.py.

![Error_ss](https://github.com/deepwavedigital/airstack-examples/assets/71423958/698b8941-a0fb-4081-ac80-5e02b2b8132a)
